### PR TITLE
feat: optional parameter to set session configuration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {
   ConfigurationParameters,
   Configuration,
 } from '@kinde-oss/kinde-typescript-sdk';
+import session from 'express-session';
 
 export * from './helpers';
 export { managementApi, GrantType, ConfigurationParameters, Configuration };
@@ -22,9 +23,10 @@ export { managementApi, GrantType, ConfigurationParameters, Configuration };
  */
 export const setupKinde = <G extends GrantType>(
   config: SetupConfig<G>,
-  app: Express
+  app: Express,
+  sessionOptions?: session.SessionOptions
 ) => {
-  setupInternalClient(app, config);
+  setupInternalClient(app, config, sessionOptions);
   setupAuthRouter(app, '/');
   return getInternalClient();
 };

--- a/src/setup/index.ts
+++ b/src/setup/index.ts
@@ -3,6 +3,7 @@ import { setupInternalClient as setupKindeClient } from './kindeClient';
 import { type GrantType } from '@kinde-oss/kinde-typescript-sdk';
 import { type SetupConfig } from './kindeSetupTypes';
 import type { Express } from 'express';
+import session from 'express-session';
 
 export { getInternalClient, getInitialConfig } from './kindeClient';
 export * from './kindeSetupTypes';
@@ -17,8 +18,9 @@ export * from './kindeSetupTypes';
  */
 export const setupInternalClient = <G extends GrantType>(
   app: Express,
-  config: SetupConfig<G>
+  config: SetupConfig<G>,
+  sessionOptions?: session.SessionOptions
 ): void => {
-  setupKindeSession(app);
+  setupKindeSession(app, sessionOptions);
   setupKindeClient(config);
 };

--- a/src/setup/sessionManager.ts
+++ b/src/setup/sessionManager.ts
@@ -7,7 +7,7 @@ const SESSION_MAX_AGE: number = 1000 * 60 * 60 * 24;
 const sessionConfig: SessionOptions = {
   secret: randomString(),
   saveUninitialized: true,
-  cookie: { 
+  cookie: {
     maxAge: SESSION_MAX_AGE,
     sameSite: 'lax',
     httpOnly: true,
@@ -47,7 +47,10 @@ const getSessionManager = (): ExpressMiddleware<void> => {
  * typescript SDK (in middleware form).
  * @param {Express} app
  */
-export const setupKindeSession = (app: Express): void => {
-  app.use(session(sessionConfig));
+export const setupKindeSession = (
+  app: Express,
+  sessionOptions?: session.SessionOptions
+): void => {
+  app.use(session(sessionOptions ?? sessionConfig));
   app.use(getSessionManager());
 };


### PR DESCRIPTION
# Explain your changes

Current there doesn't seem to be a way to use a custom session configuration, so adding a parameter that can be used to override the default.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
