### PR TITLE
feat(auth): support invitation_code flow for login/register

### DIFF
--- a/src/auth/kindeAuthRouter.test.ts
+++ b/src/auth/kindeAuthRouter.test.ts
@@ -60,6 +60,39 @@ describe("kindeAuthRouter", () => {
       );
     });
 
+    it("uses first invitation_code value when invitation_code is an array", async () => {
+      const registerURL = getMockAuthURL({ start_page: "registration" });
+      registerMock.mockResolvedValue(registerURL);
+
+      const response = await request(app)
+        .get("/register")
+        .query("invitation_code=%20inv_first%20&invitation_code=inv_second");
+
+      expect(response.status).toBe(302);
+      expect(registerMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          invitation_code: "inv_first",
+          is_invitation: "true",
+        }),
+      );
+    });
+
+    it("does not forward invitation_code when invitation_code is a non-string object", async () => {
+      const registerURL = getMockAuthURL({ start_page: "registration" });
+      registerMock.mockResolvedValue(registerURL);
+
+      const response = await request(app)
+        .get("/register")
+        .query("invitation_code[raw]=abc");
+
+      expect(response.status).toBe(302);
+      expect(registerMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.not.objectContaining({ invitation_code: expect.anything() }),
+      );
+    });
+
     it("raises exception if optional organization code is invalid", async () => {
       const query = { org_code: "" };
       const response = await request(app).get("/register").query(query);
@@ -112,6 +145,39 @@ describe("kindeAuthRouter", () => {
       const response = await request(app)
         .get("/login")
         .query({ invitation_code: "   " });
+
+      expect(response.status).toBe(302);
+      expect(loginMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.not.objectContaining({ invitation_code: expect.anything() }),
+      );
+    });
+
+    it("uses first invitation_code value when invitation_code is an array", async () => {
+      const loginURL = getMockAuthURL();
+      loginMock.mockResolvedValue(loginURL);
+
+      const response = await request(app)
+        .get("/login")
+        .query("invitation_code=%20inv_first%20&invitation_code=inv_second");
+
+      expect(response.status).toBe(302);
+      expect(loginMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          invitation_code: "inv_first",
+          is_invitation: "true",
+        }),
+      );
+    });
+
+    it("does not forward invitation_code when invitation_code is a non-string object", async () => {
+      const loginURL = getMockAuthURL();
+      loginMock.mockResolvedValue(loginURL);
+
+      const response = await request(app)
+        .get("/login")
+        .query("invitation_code[raw]=abc");
 
       expect(response.status).toBe(302);
       expect(loginMock).toHaveBeenCalledWith(

--- a/src/auth/kindeAuthRouter.test.ts
+++ b/src/auth/kindeAuthRouter.test.ts
@@ -27,6 +27,39 @@ describe("kindeAuthRouter", () => {
       expect(response.headers.location).toBe(registerURL.toString());
     });
 
+    it("starts invitation registration flow with invitation_code and is_invitation", async () => {
+      const registerURL = getMockAuthURL({ start_page: "registration" });
+      registerMock.mockResolvedValue(registerURL);
+
+      const response = await request(app)
+        .get("/register")
+        .query({ invitation_code: "inv_123" });
+
+      expect(response.status).toBe(302);
+      expect(registerMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          invitation_code: "inv_123",
+          is_invitation: "true",
+        }),
+      );
+    });
+
+    it("does not forward blank invitation_code for registration flow", async () => {
+      const registerURL = getMockAuthURL({ start_page: "registration" });
+      registerMock.mockResolvedValue(registerURL);
+
+      const response = await request(app)
+        .get("/register")
+        .query({ invitation_code: "   " });
+
+      expect(response.status).toBe(302);
+      expect(registerMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.not.objectContaining({ invitation_code: expect.anything() }),
+      );
+    });
+
     it("raises exception if optional organization code is invalid", async () => {
       const query = { org_code: "" };
       const response = await request(app).get("/register").query(query);
@@ -52,6 +85,39 @@ describe("kindeAuthRouter", () => {
       const response = await request(app).get("/login");
       expect(response.status).toBe(302);
       expect(response.headers.location).toBe(loginURL.toString());
+    });
+
+    it("starts invitation login flow with invitation_code and is_invitation", async () => {
+      const loginURL = getMockAuthURL();
+      loginMock.mockResolvedValue(loginURL);
+
+      const response = await request(app)
+        .get("/login")
+        .query({ invitation_code: "inv_123" });
+
+      expect(response.status).toBe(302);
+      expect(loginMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          invitation_code: "inv_123",
+          is_invitation: "true",
+        }),
+      );
+    });
+
+    it("does not forward blank invitation_code for login flow", async () => {
+      const loginURL = getMockAuthURL();
+      loginMock.mockResolvedValue(loginURL);
+
+      const response = await request(app)
+        .get("/login")
+        .query({ invitation_code: "   " });
+
+      expect(response.status).toBe(302);
+      expect(loginMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.not.objectContaining({ invitation_code: expect.anything() }),
+      );
     });
 
     it("raises exception if optional organization code is invalid", async () => {

--- a/src/auth/kindeAuthRouter.ts
+++ b/src/auth/kindeAuthRouter.ts
@@ -46,16 +46,28 @@ export const validateQueryParams = (requestQuery: ParsedQs): Error | null => {
  * @returns {ParsedQs}
  */
 const mapAuthFlowQueryParams = (requestQuery: ParsedQs): ParsedQs => {
-  const invitationCode = requestQuery.invitation_code;
-  if (typeof invitationCode !== "string") {
-    return requestQuery;
+  const mappedQuery = {
+    ...requestQuery,
+  };
+  const invitationCode = mappedQuery.invitation_code;
+
+  let normalizedInvitationCode: string | undefined;
+  if (typeof invitationCode === "string") {
+    normalizedInvitationCode = invitationCode;
+  } else if (
+    Array.isArray(invitationCode) &&
+    typeof invitationCode[0] === "string"
+  ) {
+    normalizedInvitationCode = invitationCode[0];
   }
 
-  const trimmedInvitationCode = invitationCode.trim();
+  if (normalizedInvitationCode === undefined) {
+    delete mappedQuery.invitation_code;
+    return mappedQuery;
+  }
+
+  const trimmedInvitationCode = normalizedInvitationCode.trim();
   if (!trimmedInvitationCode) {
-    const mappedQuery = {
-      ...requestQuery,
-    };
     delete mappedQuery.invitation_code;
     return mappedQuery;
   }

--- a/src/auth/kindeAuthRouter.ts
+++ b/src/auth/kindeAuthRouter.ts
@@ -38,6 +38,36 @@ export const validateQueryParams = (requestQuery: ParsedQs): Error | null => {
 };
 
 /**
+ * Maps incoming query params for auth flow starts.
+ *
+ * Adds `is_invitation=true` when a valid `invitation_code` is present.
+ *
+ * @param {ParsedQs} requestQuery
+ * @returns {ParsedQs}
+ */
+const mapAuthFlowQueryParams = (requestQuery: ParsedQs): ParsedQs => {
+  const invitationCode = requestQuery.invitation_code;
+  if (typeof invitationCode !== "string") {
+    return requestQuery;
+  }
+
+  const trimmedInvitationCode = invitationCode.trim();
+  if (!trimmedInvitationCode) {
+    const mappedQuery = {
+      ...requestQuery,
+    };
+    delete mappedQuery.invitation_code;
+    return mappedQuery;
+  }
+
+  return {
+    ...requestQuery,
+    invitation_code: trimmedInvitationCode,
+    is_invitation: "true",
+  };
+};
+
+/**
  * Creates login URL using internal SDK and redirects to said URL.
  *
  * @param {Request} req - The Express request object.
@@ -57,7 +87,7 @@ const handleLogin = async (
   }
 
   const client = getInternalClient<GrantType.AUTHORIZATION_CODE>();
-  const loginURL = await client.login(req, req.query);
+  const loginURL = await client.login(req, mapAuthFlowQueryParams(req.query));
   res.redirect(loginURL.toString());
 };
 
@@ -95,7 +125,10 @@ const handleRegister = async (
   }
 
   const client = getInternalClient<GrantType.AUTHORIZATION_CODE>();
-  const registerURL = await client.register(req, req.query);
+  const registerURL = await client.register(
+    req,
+    mapAuthFlowQueryParams(req.query),
+  );
   res.redirect(registerURL.toString());
 };
 

--- a/src/auth/kindeAuthRouter.ts
+++ b/src/auth/kindeAuthRouter.ts
@@ -46,35 +46,25 @@ export const validateQueryParams = (requestQuery: ParsedQs): Error | null => {
  * @returns {ParsedQs}
  */
 const mapAuthFlowQueryParams = (requestQuery: ParsedQs): ParsedQs => {
-  const mappedQuery = {
-    ...requestQuery,
-  };
-  const invitationCode = mappedQuery.invitation_code;
+  const { invitation_code: rawInvitationCode, ...restQuery } = requestQuery;
 
-  let normalizedInvitationCode: string | undefined;
-  if (typeof invitationCode === "string") {
-    normalizedInvitationCode = invitationCode;
+  let invitationCode: string | undefined;
+  if (typeof rawInvitationCode === "string") {
+    invitationCode = rawInvitationCode.trim();
   } else if (
-    Array.isArray(invitationCode) &&
-    typeof invitationCode[0] === "string"
+    Array.isArray(rawInvitationCode) &&
+    typeof rawInvitationCode[0] === "string"
   ) {
-    normalizedInvitationCode = invitationCode[0];
+    invitationCode = rawInvitationCode[0].trim();
   }
 
-  if (normalizedInvitationCode === undefined) {
-    delete mappedQuery.invitation_code;
-    return mappedQuery;
-  }
-
-  const trimmedInvitationCode = normalizedInvitationCode.trim();
-  if (!trimmedInvitationCode) {
-    delete mappedQuery.invitation_code;
-    return mappedQuery;
+  if (!invitationCode) {
+    return restQuery;
   }
 
   return {
-    ...requestQuery,
-    invitation_code: trimmedInvitationCode,
+    ...restQuery,
+    invitation_code: invitationCode,
     is_invitation: "true",
   };
 };


### PR DESCRIPTION
# Explain your changes

Map incoming `invitation_code` to auth params and auto-include `is_invitation=true`.
Test notes: added login/register router tests asserting forwarded params.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
